### PR TITLE
feat: Add CI + fix test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,38 @@
+name: AsteriscCI
+on: [push]
+
+jobs:
+  go-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Install Golang
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.x'
+      - name: Build rvsol
+        run: forge build
+        working-directory: rvsol
+      - name: Build rv64g test binaries
+        run: make bin bin/simple bin/minimal
+        working-directory: tests/go-tests
+      - name: Run tests
+        run: go test -v ./...
+        working-directory: rvgo
+  # go-lint:
+  #   runs-on: ubuntu-latest
+  #   timeout-minutes: 20
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.21.x'
+  #         cache: false
+  #     - name: golangci-lint
+  #       uses: golangci/golangci-lint-action@v3
+  #       with:
+  #         version: latest

--- a/rvgo/fast/memory_test.go
+++ b/rvgo/fast/memory_test.go
@@ -29,7 +29,7 @@ func TestMemoryMerkleProof(t *testing.T) {
 		m.SetUnaligned(0x13370000, []byte{123})
 		root := m.MerkleRoot()
 		proof := m.MerkleProof(0x80004)
-		require.Equal(t, uint32(42), binary.BigEndian.Uint32(proof[4:8]))
+		require.Equal(t, uint32(42<<24), binary.BigEndian.Uint32(proof[4:8]))
 		node := *(*[32]byte)(proof[:32])
 		path := uint32(0x80004) >> 5
 		for i := 32; i < len(proof); i += 32 {
@@ -111,7 +111,6 @@ func TestMemoryMerkleRoot(t *testing.T) {
 }
 
 func TestMemoryReadWrite(t *testing.T) {
-
 	t.Run("large random", func(t *testing.T) {
 		m := NewMemory()
 		data := make([]byte, 20_000)


### PR DESCRIPTION
## Overview

Adds a CI workflow with go build caching for the `rvgo` tests. Also templates out a `golangci-lint` job, which is currently throwing up a ton of errors. Will follow up with another PR to fix those and enable that job.

Also fixes the "fuller tree" test in `TestMemoryMerkleProof`, where the test assertion assumed that the `0x2A` byte would be right-aligned in the 32-bit slice of the proof. `SetUnaligned` always writes the bytes passed verbatim starting at the given memory address, so the 4 byte proof element should be `0x2a000000` rather than `0x0000002a`.